### PR TITLE
MathJax replace katex - seems to be working fine

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,19 +17,36 @@
     </main>
 
     {%- include footer.html -%}
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
-    <script>
-      document.addEventListener("DOMContentLoaded", function() {
-          renderMathInElement(document.body, {
-              delimiters: [
-                {left: "$$", right: "$$", display: true},
-                {left: "$", right: "$", display: false},
-                {left: "\\[", right: "\\]", display: true},
-                {left: "\\(", right: "\\)", display: false},
-              ]
-          });
+
+    <!-- mathjax config from https://quuxplusone.github.io/blog/2018/08/05/mathjax-in-jekyll/ -->
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        tex2jax: {
+          inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+          processEscapes: true
+        },
+        extensions: [
+          "MathMenu.js",
+          "MathZoom.js",
+          "AssistiveMML.js",
+          "a11y/accessibility-menu.js"
+        ],
+        jax: ["input/TeX", "output/CommonHTML"],
+        TeX: {
+          extensions: [
+            "AMSmath.js",
+            "AMSsymbols.js",
+            "noErrors.js",
+            "noUndefined.js",
+          ],
+          equationNumbers: {
+            autoNumber: "AMS"
+          }
+        }
       });
+    </script>
+    <script type="text/javascript" async
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML">
     </script>
 
   </body>


### PR DESCRIPTION
Appears to be working fine and was a breeze, I just followed [this blog post](https://quuxplusone.github.io/blog/2018/08/05/mathjax-in-jekyll/)

and added a couple lines for inline math delimiters and automatic equation numbering.

Varun's blog post appears to be working fine.

Some features I found that I like over katex:
- automatic equation numbering _and_ `\label`, `\ref`, and `\eqref`
- `align` environment
- less picky about parsing (katex was very picky about having spaces at the ends of lines and was generally very frustrating to "debug")