### PR TITLE
Add CC license for uncertainties posts graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,8 @@ Bad flow:
 4. Fix all issues as axcz did :-(
 
 Better flow would maybe use better convertor, e.g. HTML export. Manual editing of html seems non-maintainable.
+
+
+### Reusing graphics
+
+The source graphics of _"Reducing the uncertainty about the uncertainties"_ ([part 1](https://gtsam.org/2021/02/23/uncertainties-part1.html), [part 2](https://gtsam.org/2021/02/23/uncertainties-part2.html), and [part 3](https://gtsam.org/2021/02/23/uncertainties-part3.html)) are available in the file [uncertainties_graphics_main.svg](https://github.com/borglab/gtsam.org/blob/master/assets/images/uncertainties/uncertainties_graphics_main.svg) © 2021 by [Matias Mattamala](https://mmattamala.github.io), which is licensed under [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/?ref=chooser-v1) <img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1" alt="">


### PR DESCRIPTION
Hi @dellaert 

This adds the CC BY license as discussed in https://github.com/borglab/gtsam.org/issues/63 for the figures I made for the uncertainties posts

Let me know if there is anything I should change